### PR TITLE
加个简单边框，纯色多的情况下可以识别截图后的窗体。

### DIFF
--- a/suspend.html
+++ b/suspend.html
@@ -26,6 +26,8 @@
         height: auto;
         border-radius: 6px;
         overflow: hidden !important;
+        box-sizing: border-box;
+        border: 2px solid red;
     }
 </style>
 


### PR DESCRIPTION
很好用的插件~~

这里调整一点点，方便截图识别浮动窗口位置。